### PR TITLE
Skipping already downloaded images

### DIFF
--- a/get_tiles.py
+++ b/get_tiles.py
@@ -21,7 +21,8 @@ def genVideo(frame: str, left: int, upper: int, right: int, lower: int, out: str
         spamreader = csv.reader(csvfile, delimiter=',', quotechar='|')
         with alive_bar(row_count) as bar:
             for index, row in enumerate(spamreader):
-                clipImage(index, row[0], 'https://garlic-bread.reddit.com/media/canvas-images/full-frame/' + row[1], left, upper, right, lower, out)
+                if not os.path.exists(f'{out}/{index:05}.png'):
+                    clipImage(index, row[0], 'https://garlic-bread.reddit.com/media/canvas-images/full-frame/' + row[1], left, upper, right, lower, out)
                 bar()
 
 def main():

--- a/get_tiles.py
+++ b/get_tiles.py
@@ -1,6 +1,7 @@
 import argparse
 import csv
 from io import BytesIO
+import os
 
 import requests
 from PIL import Image


### PR DESCRIPTION
I encountered a problem that if something happens with Internet connection while downloading images the only thing I can do is to start the process all over again, downloading already existing images. So I added a _very primitive_ feature that makes it so every image that has name representing its index number gets automatically skipped. Now it's just working constantly, however, if you want me to make it toggleable, just let me know